### PR TITLE
Fix type error in Twitter metadata configuration

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,7 +26,7 @@ export function constructMetadata({
       images: [{ url: image }],
     },
     twitter: {
-      card: 'kkalsfgioa',
+      card: 'summary_large_image',
       title,
       description,
       images: [image],


### PR DESCRIPTION
- Corrected the 'card' property in Twitter metadata to match allowed values: "summary", "summary_large_image", "player", "app".
- Adjusted the code to ensure proper type assignment and prevent deployment errors.